### PR TITLE
Node example

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -1,4 +1,4 @@
-## Quick Example for a PHP Worker (4 minutes)
+## Quick Example for a Node Worker (4 minutes)
 
 This example will show you how to include dependencies with your worker so it will work right when you run it
 remotely on IronWorker.
@@ -12,14 +12,14 @@ npm install
 Now run the example worker in this repo called `hello.js`, outside of the Iron.io container.
 
 ```sh
-node hello.js -payload hello.payload.json
+node hello.js --payload hello.payload.json
 ```
 
 Now try running it in an Iron.io Docker container, [stack](http://dev.iron.io/worker/reference/environment/#default_language_versions), (if this is your first time running this, it will take a bit to download
 the Docker container so be patient, it will only do it the first time):
 
 ```sh
-docker run --rm -v "$(pwd)":/usr/src/myapp -w /usr/src/myapp iron/images:node-0.10 sh -c 'node hello.js -payload hello.payload.json'
+docker run --rm -v "$(pwd)":/usr/src/myapp -w /usr/src/myapp iron/images:node-0.10 sh -c 'node hello.js --payload hello.payload.json'
 ```
 
 It works! And now that it works, we know it will work on IronWorker.

--- a/node/README.md
+++ b/node/README.md
@@ -1,0 +1,51 @@
+## Quick Example for a PHP Worker (4 minutes)
+
+This example will show you how to include dependencies with your worker so it will work right when you run it
+remotely on IronWorker.
+
+Note: You'll need Node.js installed on your machine to use this example.
+
+Install the dependencies to your system.
+```sh
+npm install
+```
+Now run the example worker in this repo called `hello.js`, outside of the Iron.io container.
+
+```sh
+node hello.js -payload hello.payload.json
+```
+
+Now try running it in an Iron.io Docker container, [stack](http://dev.iron.io/worker/reference/environment/#default_language_versions), (if this is your first time running this, it will take a bit to download
+the Docker container so be patient, it will only do it the first time):
+
+```sh
+docker run --rm -v "$(pwd)":/usr/src/myapp -w /usr/src/myapp iron/images:node-0.10 sh -c 'node hello.js -payload hello.payload.json'
+```
+
+It works! And now that it works, we know it will work on IronWorker.
+
+Let's package it up:
+
+```sh
+zip -r hello.zip .
+```
+
+Then upload it:
+
+```sh
+iron worker upload --stack node-0.10 hello.zip node hello.js
+```
+
+Notice the --stack parameter is the same as the Docker container we used above.
+
+And finally queue up a job for it!
+
+```sh
+iron worker queue --payload-file hello.payload.json --wait hello
+```
+
+The `--wait` parameter waits for the job to finish, then prints the output.
+You will also see a link to [HUD](http://hud.iron.io) where you can see all the rest of the task details along with the log output.
+
+
+

--- a/node/hello.js
+++ b/node/hello.js
@@ -1,0 +1,11 @@
+
+var iw = require('node_helper');
+var iron_mq = require('iron_mq');
+
+console.log("task_id:", iw.task_id);
+console.log("params:", iw.params);
+console.log("config:", iw.config);
+
+var imq = new iron_mq.Client({token: "MY_TOKEN", project_id: "MY_PROJECT_ID", queue_name: "MY_QUEUE"});
+
+console.log("IronMQ Client: ", imq);

--- a/node/hello.payload.json
+++ b/node/hello.payload.json
@@ -1,0 +1,3 @@
+{
+    "name": "Johnny"
+}

--- a/node/node_modules/node_helper.js
+++ b/node/node_modules/node_helper.js
@@ -1,0 +1,35 @@
+var fs = require('fs');
+var querystring = require('querystring');
+var params = null;
+var task_id = null;
+var config = null;
+
+process.argv.forEach(function(val, index, array) {
+  if (val == "-payload") {
+    params = fs.readFileSync(process.argv[index + 1], 'utf8');
+    try {
+      params = JSON.parse(params);
+    } catch(e) {
+      try {
+        var parsed = querystring.parse(params);
+        if (!(Object.keys(parsed).length == 1 && parsed[Object.keys(parsed)[0]] == '')) {
+          params = parsed
+        }
+      } catch(e) {
+
+      }
+    }
+  }
+
+  if (val == "-config") {
+    config = JSON.parse(fs.readFileSync(process.argv[index + 1], 'utf8'));
+  }
+
+  if (val == "-id") {
+    task_id = process.argv[index + 1];
+  }
+});
+
+exports.params = params;
+exports.config = config;
+exports.task_id = task_id;

--- a/node/node_modules/node_helper.js
+++ b/node/node_modules/node_helper.js
@@ -5,7 +5,7 @@ var task_id = null;
 var config = null;
 
 process.argv.forEach(function(val, index, array) {
-  if (val == "-payload") {
+  if (val == "-payload" || val == "--payload") {
     params = fs.readFileSync(process.argv[index + 1], 'utf8');
     try {
       params = JSON.parse(params);
@@ -21,11 +21,11 @@ process.argv.forEach(function(val, index, array) {
     }
   }
 
-  if (val == "-config") {
+  if (val == "-config" || val == "--config" ) {
     config = JSON.parse(fs.readFileSync(process.argv[index + 1], 'utf8'));
   }
 
-  if (val == "-id") {
+  if (val == "-id" || val == "--id") {
     task_id = process.argv[index + 1];
   }
 });

--- a/node/package.json
+++ b/node/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "iron_mq": "*"
+  }
+}

--- a/php/helper.php
+++ b/php/helper.php
@@ -10,10 +10,10 @@ function getArgs($assoc = true) {
   foreach ($argv as $k => $v) {
     if (empty($argv[$k + 1])) continue;
 
-    if ($v == '-id') $args['task_id'] = $argv[$k + 1];
-    if ($v == '-d')  $args['dir']     = $argv[$k + 1];
+    if ($v == '-id' || $v == '--id') $args['task_id'] = $argv[$k + 1];
+    if ($v == '-d' || $v == '--d')  $args['dir']     = $argv[$k + 1];
 
-    if ($v == '-payload' && file_exists($argv[$k + 1])) {
+    if (($v == '-payload' || $v == '--payload') && file_exists($argv[$k + 1])) {
       $args['payload'] = file_get_contents($argv[$k + 1]);
 
       $parsed_payload = json_decode($args['payload'], $assoc);
@@ -23,7 +23,7 @@ function getArgs($assoc = true) {
       }
     }
 
-    if ($v == '-config' && file_exists($argv[$k + 1])) {
+    if (($v == '-config' || $v == '--config') && file_exists($argv[$k + 1])) {
       $args['config'] = file_get_contents($argv[$k + 1]);
 
       $parsed_config = json_decode($args['config'], $assoc);


### PR DESCRIPTION
@treeder Note : is that ok - i see difference in param names, `--payload` vs `-payload` e.g.
Current example is ok but other ones handle only old notation (`-payload`)

``` js
process.argv:  [ 'node',
  '/mnt/task/hello.js',
  '--dir',
  '/mnt/task/',
  '-e',
  'production',
  '--id',
  '54e4b142357434291701641a',
  '--payload',
  '/mnt/task/task_payload.json' ]
```
